### PR TITLE
Add class with arbitrary saturation boundaries

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: saline
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - Benjamin Wade

--- a/spec/clamped_spec.cr
+++ b/spec/clamped_spec.cr
@@ -1,0 +1,150 @@
+require "./spec_helper"
+
+describe Clamped do
+  describe ".new" do
+    it "sets the internal value based on the argument" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      n.should eq 7
+    end
+
+    it "disallows non-`Number` types" do
+      assert_error(
+        "compiler/clamped_only_numbers.cr",
+        "The generic type of Clamped must be a Number type!"
+      )
+    end
+
+    it "enforces numeric lower bound" do
+      assert_error(
+        "compiler/clamped_numeric_lower_bound.cr",
+        "The generic lower bound of Clamped must be a number literal!"
+      )
+    end
+
+    it "enforces numeric upper bound" do
+      assert_error(
+        "compiler/clamped_numeric_upper_bound.cr",
+        "The generic upper bound of Clamped must be a number literal!"
+      )
+    end
+
+    it "enforces partial ordering of lower and upper bounds" do
+      assert_error(
+        "compiler/clamped_bound_ordering.cr",
+        "The generic upper bound of Clamped must not be less than its generic lower bound!"
+      )
+    end
+  end
+
+  describe "#+" do
+    it "adds a Number normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 11
+
+      result = n + 6
+
+      result.should eq 17
+    end
+
+    it "adds another Clamped normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 19
+      m = Clamped(Int32, Int32::MIN, Int32::MAX).new 4
+
+      result = n + m
+
+      result.should eq 23
+    end
+
+    # TODO: test Clamped with different generic types
+
+    it "clamps when generic type would exceed upper bound" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      result = n + 5
+
+      result.should eq 11
+    end
+
+    it "clamps when generic type would exceed lower bound" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      result = n + -11
+
+      result.should eq 2
+    end
+  end
+
+  describe "#-" do
+    it "subtracts a Number normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 11
+
+      result = n - 4
+
+      result.should eq 7
+    end
+
+    it "subtracts another Clamped normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 19
+      m = Clamped(Int32, Int32::MIN, Int32::MAX).new 6
+
+      result = n - m
+
+      result.should eq 13
+    end
+
+    # TODO: test Clamped with different generic types
+
+    it "clamps when generic type would exceed upper bound" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      result = n - -5
+
+      result.should eq 11
+    end
+
+    it "clamps when generic type would exceed lower bound" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      result = n - 11
+
+      result.should eq 2
+    end
+  end
+
+  describe "#*" do
+    it "multiplies a Number normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 2
+
+      result = n * 3
+
+      result.should eq 6
+    end
+
+    it "multiplies another Clamped normally" do
+      n = Clamped(Int32, Int32::MIN, Int32::MAX).new 5
+      m = Clamped(Int32, Int32::MIN, Int32::MAX).new 7
+
+      result = n * m
+
+      result.should eq 35
+    end
+
+    # TODO: test Clamped with different generic types
+
+    it "clamps when generic type would exceed upper bound" do
+      n = Clamped(Int32, 0, 11).new 7
+
+      result = n * 2
+
+      result.should eq 11
+    end
+
+    it "clamps when generic type would exceed lower bound" do
+      n = Clamped(Int32, 2, 11).new 7
+
+      result = n * -1
+
+      result.should eq 2
+    end
+  end
+end

--- a/spec/compiler/clamped_bound_ordering.cr
+++ b/spec/compiler/clamped_bound_ordering.cr
@@ -1,0 +1,3 @@
+require "../spec_helper"
+
+n = Clamped(Int32, 2, 1).new(1)

--- a/spec/compiler/clamped_numeric_lower_bound.cr
+++ b/spec/compiler/clamped_numeric_lower_bound.cr
@@ -1,0 +1,3 @@
+require "../spec_helper"
+
+n = Clamped(Int32, Int32, 11).new(5)

--- a/spec/compiler/clamped_numeric_upper_bound.cr
+++ b/spec/compiler/clamped_numeric_upper_bound.cr
@@ -1,0 +1,3 @@
+require "../spec_helper"
+
+n = Clamped(Int32, 2, Int32).new(5)

--- a/spec/compiler/clamped_only_numbers.cr
+++ b/spec/compiler/clamped_only_numbers.cr
@@ -1,0 +1,3 @@
+require "../spec_helper"
+
+n = Clamped(String, 2, 11).new("Something")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,8 @@
 require "spec"
 require "../src/saline"
 
+include Saline
+
 # Asserts compile time errors given a *path* to a program and a *message*.
 #
 # This was copied straight from the spec_helper in

--- a/src/saline/clamped.cr
+++ b/src/saline/clamped.cr
@@ -1,3 +1,5 @@
+require "./saturating"
+
 module Saline
   # # A `Clamped` `Number` clamps to given minimum and maximum values.
   #

--- a/src/saline/clamped.cr
+++ b/src/saline/clamped.cr
@@ -46,6 +46,7 @@ module Saline
       @_value = Saturating(T).new L if @_value < L
     end
 
+    # :ditto:
     def self.new(value : T)
       {% unless T < Number %}
         {% raise "The generic type of Clamped must be a Number type!" %}
@@ -53,6 +54,7 @@ module Saline
       new Saturating(T).new(value)
     end
 
+    # Get the `Number` value represented by this `Clamped(T, L, U)`
     def value
       @_value.value
     end

--- a/src/saline/clamped.cr
+++ b/src/saline/clamped.cr
@@ -1,0 +1,127 @@
+module Saline
+  # # A `Clamped` `Number` clamps to given minimum and maximum values.
+  #
+  # This wrapper type changes arithmetic behavior to clamp at the given lower
+  # bound `L` and upper bound `U`. The code snippet below demonstrates
+  # this concept with an Int32.
+  #
+  # ```crystal
+  # n = Clamped(Int32, 2, 11).new(7)
+  # n += 5 # => 11
+  # n = Clamped(Int32, 2, 11).new(7)
+  # n -= 11 # => 2
+  # ```
+  #
+  # Note: This class will only work with `Number` types. In order to avoid
+  #       unexpected behavior, `T` is checked at compile-time to determine
+  #       whether it is a `Number` type.
+  struct Clamped(T, L, U)
+    include Comparable(T)
+    include Comparable(Clamped(T, L, U))
+
+    # The `Number` value represented by this `Clamped(T, L, U)`
+    getter value : T
+
+    # Create a new `Clamped(T, L, U)` with the given *value*.
+    def initialize(@value : T)
+      {% unless T < Number %}
+        {% raise "The generic type of Clamped must be a Number type!" %}
+      {% end %}
+      {% unless L.is_a? NumberLiteral %}
+        {% raise "The generic lower bound of Clamped must be a number literal!" %}
+      {% end %}
+      {% unless U.is_a? NumberLiteral %}
+        {% raise "The generic upper bound of Clamped must be a number literal!" %}
+      {% end %}
+      {% if U < L %}
+        {% raise "The generic upper bound of Clamped must not be less than its generic lower bound!" %}
+      {% end %}
+
+      # TODO: check initial value
+    end
+
+    # Returns the result of adding `self` and *other*.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def +(other : Number) : Clamped(T, L, U)
+      if other < 0
+        self - (-other)
+      else
+        begin
+          if (new_value = value + other) <= U
+            Clamped(T, L, U).new(new_value)
+          else
+            Clamped(T, L, U).new(U)
+          end
+        rescue OverflowError
+          Clamped(T, L, U).new(U)
+        end
+      end
+    end
+
+    # Returns the result of subtracting *other* from `self`.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def -(other : Number) : Clamped(T, L, U)
+      if other < 0
+        self + (-other)
+      else
+        begin
+          if (new_value = value - other) >= L
+            Clamped(T, L, U).new(new_value)
+          else
+            Clamped(T, L, U).new(L)
+          end
+        rescue OverflowError
+          Clamped(T, L, U).new(L)
+        end
+      end
+    end
+
+    # Returns the result of multiplying `self` and *other*.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def *(other : T) : Clamped(T, L, U)
+      begin
+        if (new_value = self.value * other) > U
+          Clamped(T, L, U).new(U)
+        elsif new_value < L
+          Clamped(T, L, U).new(L)
+        else
+          Clamped(T, L, U).new(new_value)
+        end
+      rescue OverflowError
+        if (value < 0) ^ (other < 0) # true if negative product, otherwise false
+          Clamped(T, L, U).new(L)
+        else
+          Clamped(T, L, U).new(U)
+        end
+      end
+    end
+
+    # Returns the result of adding `self` and *other*.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def +(other : Clamped(T, L, U)) : Clamped(T, L, U)
+      self + other.value
+    end
+
+    # Returns the result of subtracting *other* from `self`.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def -(other : Clamped(T, L, U)) : Clamped(T, L, U)
+      self - other.value
+    end
+
+    # Returns the result of multiplying `self` and *other*.
+    # Returns `U` or `L` (as appropriate) in case of overflow.
+    def *(other : Clamped(T, L, U)) : Clamped(T, L, U)
+      self * other.value
+    end
+
+    def <=>(other : Clamped(T, L, U))
+      self.value <=> other.value
+    end
+
+    def <=>(other : Number)
+      self.value <=> other
+    end
+
+    forward_missing_to value
+  end
+end


### PR DESCRIPTION
This PR adds the `Clamped` class, which allows for arbitrary saturation boundaries, per #4.

The saturation boundaries are defined with generic arguments, so a `Clamped(Int32, 0, 12)` has an `Int32` value that will always be in the range [0, 12], saturating at the boundaries.

I intend to add benchmarks here, but I expect this to be quite slow right now. It's built on `Saturating`, which currently uses exception catching to prevent overflow. However, once I change `Saturating` to use the built-in LLVM functions, the performance of both structures should improve dramatically.