### PR TITLE
Add benchmarks

### DIFF
--- a/benchmarks/asymmetric_saturating.cr
+++ b/benchmarks/asymmetric_saturating.cr
@@ -4,10 +4,11 @@ require "../src/saline.cr"
 include Saline
 
 fake_val = 0
-Benchmark.ips do |x|
-  {% begin %}
-    {% for first_type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
-      {% for second_type in ([Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64].reject { |type| type == first_type }) %}
+{% begin %}
+  {% for first_type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
+    {% for second_type in ([Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64].reject { |type| type == first_type }) %}
+      puts "{{first_type}} and {{second_type}}"
+      Benchmark.ips do |x|
         x.report("Saturating({{first_type}}) + Saturating({{second_type}}), no saturation") do
           val_{{first_type}} = Saturating({{first_type}}).new(1)
           val_{{second_type}} = Saturating({{second_type}}).new(2)
@@ -43,7 +44,8 @@ Benchmark.ips do |x|
           val_{{second_type}} = Saturating({{second_type}}).new({{second_type}}::MAX - 1)
           fake_val = val_{{first_type}} * val_{{second_type}}
         end
-      {% end %}
+      end
+      puts ""
     {% end %}
   {% end %}
-end
+{% end %}

--- a/benchmarks/asymmetric_saturating.cr
+++ b/benchmarks/asymmetric_saturating.cr
@@ -1,0 +1,49 @@
+require "benchmark"
+require "../src/saline.cr"
+
+include Saline
+
+fake_val = 0
+Benchmark.ips do |x|
+  {% begin %}
+    {% for first_type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
+      {% for second_type in ([Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64].reject { |type| type == first_type }) %}
+        x.report("Saturating({{first_type}}) + Saturating({{second_type}}), no saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new(1)
+          val_{{second_type}} = Saturating({{second_type}}).new(2)
+          fake_val = val_{{first_type}} + val_{{second_type}}
+        end
+
+        x.report("Saturating({{first_type}}) - Saturating({{second_type}}), no saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new(2)
+          val_{{second_type}} = Saturating({{second_type}}).new(1)
+          fake_val = val_{{first_type}} - val_{{second_type}}
+        end
+
+        x.report("Saturating({{first_type}}) * Saturating({{second_type}}), no saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new(3)
+          val_{{second_type}} = Saturating({{second_type}}).new(2)
+          fake_val = val_{{first_type}} * val_{{second_type}}
+        end
+
+        x.report("Saturating({{first_type}}) + Saturating({{second_type}}), with saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new({{first_type}}::MAX - 2)
+          val_{{second_type}} = Saturating({{second_type}}).new({{second_type}}::MAX - 1)
+          fake_val = val_{{first_type}} + val_{{second_type}}
+        end
+
+        x.report("Saturating({{first_type}}) - Saturating({{second_type}}), with saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new({{first_type}}::MIN + 1)
+          val_{{second_type}} = Saturating({{second_type}}).new(2)
+          fake_val = val_{{first_type}} - val_{{second_type}}
+        end
+
+        x.report("Saturating({{first_type}}) * Saturating({{second_type}}), with saturation") do
+          val_{{first_type}} = Saturating({{first_type}}).new({{first_type}}::MAX - 2)
+          val_{{second_type}} = Saturating({{second_type}}).new({{second_type}}::MAX - 1)
+          fake_val = val_{{first_type}} * val_{{second_type}}
+        end
+      {% end %}
+    {% end %}
+  {% end %}
+end

--- a/benchmarks/symmetric_saturating.cr
+++ b/benchmarks/symmetric_saturating.cr
@@ -4,9 +4,10 @@ require "../src/saline.cr"
 include Saline
 
 fake_val = 0
-Benchmark.ips do |x|
-  {% begin %}
-    {% for type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
+{% begin %}
+  {% for type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
+    puts "{{type}}"
+    Benchmark.ips do |x|
       x.report("Saturating({{type}}) + Saturating({{type}}), no saturation") do
         first_{{type}} = Saturating({{type}}).new(1)
         second_{{type}} = Saturating({{type}}).new(2)
@@ -42,6 +43,7 @@ Benchmark.ips do |x|
         second_{{type}} = Saturating({{type}}).new({{type}}::MAX - 1)
         fake_val = first_{{type}} * second_{{type}}
       end
-    {% end %}
+    end
+    puts ""
   {% end %}
-end
+{% end %}

--- a/benchmarks/symmetric_saturating.cr
+++ b/benchmarks/symmetric_saturating.cr
@@ -1,0 +1,47 @@
+require "benchmark"
+require "../src/saline.cr"
+
+include Saline
+
+fake_val = 0
+Benchmark.ips do |x|
+  {% begin %}
+    {% for type in {Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64} %}
+      x.report("Saturating({{type}}) + Saturating({{type}}), no saturation") do
+        first_{{type}} = Saturating({{type}}).new(1)
+        second_{{type}} = Saturating({{type}}).new(2)
+        fake_val = first_{{type}} + second_{{type}}
+      end
+
+      x.report("Saturating({{type}}) - Saturating({{type}}), no saturation") do
+        first_{{type}} = Saturating({{type}}).new(2)
+        second_{{type}} = Saturating({{type}}).new(1)
+        fake_val = first_{{type}} - second_{{type}}
+      end
+
+      x.report("Saturating({{type}}) * Saturating({{type}}), no saturation") do
+        first_{{type}} = Saturating({{type}}).new(3)
+        second_{{type}} = Saturating({{type}}).new(2)
+        fake_val = first_{{type}} * second_{{type}}
+      end
+
+      x.report("Saturating({{type}}) + Saturating({{type}}), with saturation") do
+        first_{{type}} = Saturating({{type}}).new({{type}}::MAX - 2)
+        second_{{type}} = Saturating({{type}}).new({{type}}::MAX - 1)
+        fake_val = first_{{type}} + second_{{type}}
+      end
+
+      x.report("Saturating({{type}}) - Saturating({{type}}), with saturation") do
+        first_{{type}} = Saturating({{type}}).new({{type}}::MIN + 1)
+        second_{{type}} = Saturating({{type}}).new(2)
+        fake_val = first_{{type}} - second_{{type}}
+      end
+
+      x.report("Saturating({{type}}) * Saturating({{type}}), with saturation") do
+        first_{{type}} = Saturating({{type}}).new({{type}}::MAX - 2)
+        second_{{type}} = Saturating({{type}}).new({{type}}::MAX - 1)
+        fake_val = first_{{type}} * second_{{type}}
+      end
+    {% end %}
+  {% end %}
+end

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: saline
-version: 0.1.1
+version: 0.1.2
 crystal: 0.34.0
 
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -1,9 +1,14 @@
 name: saline
 version: 0.1.1
+crystal: 0.34.0
+
+license: MIT
 
 authors:
   - Benjamin Wade
 
-crystal: 0.34.0
-
-license: MIT
+targets:
+  symmetric_saturating_benchmark:
+    main: benchmarks/symmetric_saturating.cr
+  asymmetric_saturating_benchmark:
+    main: benchmarks/asymmetric_saturating.cr

--- a/src/saline/saturating.cr
+++ b/src/saline/saturating.cr
@@ -34,63 +34,57 @@ module Saline
     # Returns the result of adding `self` and *other*.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
     def +(other : Number) : Saturating(T)
-      if other < 0
-        self - (-other)
+      new_value = value + other
+      Saturating(T).new(new_value)
+    rescue OverflowError
+      if other > 0
+        Saturating(T).new(T::MAX)
       else
-        begin
-          new_value = value + other
-          Saturating(T).new(new_value)
-        rescue OverflowError
-          Saturating(T).new(T::MAX)
-        end
+        Saturating(T).new(T::MIN)
       end
     end
 
     # Returns the result of subtracting *other* from `self`.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
     def -(other : Number) : Saturating(T)
-      if other < 0
-        self + (-other)
+      new_value = value - other
+      Saturating(T).new(new_value)
+    rescue OverflowError
+      if other > 0
+        Saturating(T).new(T::MIN)
       else
-        begin
-          new_value = value - other
-          Saturating(T).new(new_value)
-        rescue OverflowError
-          Saturating(T).new(T::MIN)
-        end
+        Saturating(T).new(T::MAX)
       end
     end
 
     # Returns the result of multiplying `self` and *other*.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
-    def *(other : T) : Saturating(T)
-      begin
-        new_value = value * other
-        Saturating.new(new_value)
-      rescue OverflowError
-        if (value < 0) ^ (other < 0) # this does cancelling of negative signs
-          Saturating(T).new(T::MIN)
-        else
-          Saturating(T).new(T::MAX)
-        end
+    def *(other : Number) : Saturating(T)
+      new_value = value * other
+      Saturating(T).new(new_value)
+    rescue OverflowError
+      if (value < 0) ^ (other < 0) # this does cancelling of negative signs
+        Saturating(T).new(T::MIN)
+      else
+        Saturating(T).new(T::MAX)
       end
     end
 
     # Returns the result of adding `self` and *other*.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
-    def +(other : Saturating(T)) : Saturating(T)
+    def +(other : Saturating) : Saturating(T)
       self + other.value
     end
 
     # Returns the result of subtracting *other* from `self`.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
-    def -(other : Saturating(T)) : Saturating(T)
+    def -(other : Saturating) : Saturating(T)
       self - other.value
     end
 
     # Returns the result of multiplying `self` and *other*.
     # Returns `T::MAX` or `T::MIN` (as appropriate) in case of overflow.
-    def *(other : Saturating(T)) : Saturating(T)
+    def *(other : Saturating) : Saturating(T)
       self * other.value
     end
 
@@ -101,7 +95,5 @@ module Saline
     def <=>(other : Number)
       self.value <=> other
     end
-
-    forward_missing_to value
   end
 end


### PR DESCRIPTION
This PR mostly adds benchmarks to allow for comparisons between shard versions. However, in order to allow for asymmetric operations I had to make some code changes (which didn't seem to affect performance).

Because the saturation is achieved using exceptions, the no-saturation case is very fast, but the saturation case is 2200-2300x slower for symmetric operations and 2400-2500x slower for asymmetric operations.